### PR TITLE
Hackathon dataset prep

### DIFF
--- a/sample_data/district7_roads.parquet
+++ b/sample_data/district7_roads.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b16d36d66188260d11eccea46fa136f999164f5e481c3cf504a686bc7276b1f
+size 34194666

--- a/sample_data/segments.parquet
+++ b/sample_data/segments.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b6e0a5713a98063678494961aa2926873263d71045ac9b4b9b486456fd3f034
+size 10170655

--- a/sample_data/shapes.parquet
+++ b/sample_data/shapes.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3fca5b72d477334c5fee70f72b64bbfe8db2f0f5e98ec4a192a9c1c6d310378
+size 1939155

--- a/sample_data/stop_times.parquet
+++ b/sample_data/stop_times.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcba51a95e303a67cd7406b8d818fb4b4638ca6b720a66b34c8cd71cc1b17a38
+size 4773670

--- a/sample_data/stops.parquet
+++ b/sample_data/stops.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3baf0cc2deb7d5edd2bcd96644f461da4c60f6a2361e7b7ad4f5544ddc51ec7d
+size 585425

--- a/sample_data/trips.parquet
+++ b/sample_data/trips.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70a26de9c1b1aaddc18f66919db093e7049c49e81b879903f33a828aaa46af4
+size 656745

--- a/sample_data/vp.parquet
+++ b/sample_data/vp.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411cc3f15b9b9a83470335055dda94ec7b7c4df9784eda9c5a213932476b0e5f
+size 38171493

--- a/scripts/compare_utils.py
+++ b/scripts/compare_utils.py
@@ -20,19 +20,28 @@ def speed_stats(gdf):
     display(speeds_calculated.speed_mph.hist(bins=range(0, 80, 5)))
     return
 
-def speed_map(speed_gdf: gpd.GeoDataFrame):
+def speed_map(
+    speed_gdf: gpd.GeoDataFrame,
+    static: bool = False
+):
     COLORSCALE = branca.colormap.step.RdBu_10.scale(vmin=0, vmax=80)
     drop_cols = speed_gdf.select_dtypes("datetime").columns
     
-    m = speed_gdf[(
+    gdf = speed_gdf[(
         speed_gdf.speed_mph.notna()) & 
         (speed_gdf.speed_mph < np.inf)
     ].drop(
         columns = drop_cols
     ).set_geometry(
         "segment_geometry"
-    ).explore(
-        "speed_mph", cmap=COLORSCALE,
-        tiles = "CartoDB Positron"
     )
+    
+    if static:
+        m = gdf.plot("speed_mph", cmap="RdBu", scheme="quantiles", k=10, vmin=0, vmax=80)
+
+    else:
+        m = gdf.explore(
+            "speed_mph", cmap=COLORSCALE,
+            tiles = "CartoDB Positron"
+        )
     return m 


### PR DESCRIPTION
* Allow for aggregating across time (2 dates), operators (we have 5 small/mid-sized operators), space (share same roads)
   * Get everything that is from the Cal-ITP warehouse and subset it to certain operators in LA
   * West LA - Big Blue Bus, Bruin Bus, Culver City. Their routes sometimes overlap on some major corridors.
   * Downtown LA - LADOT and Santa Clarita. Their routes sometimes overlap and run on some freeways as well as dense, urban areas.
   * GTFS schedule tables - `trips`, `shapes`, `stops`, and `stop_times` are already assembled for 2 service dates and 5 operators, with the `schedule_gtfs_dataset_key` attached, ready to use with vehicle positions
   * GTFS vehicle position tables - our deduped [fct_vehicle_locations table](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.fct_vehicle_locations), which has `trip_instance_key` and `schedule_gtfs_dataset_key` ready to merge with schedule tables
   * stop to stop segments - these were created with `gtfs_segments` for the operators / service dates already, use this to start mapping results
   * Roads - get District 7 roads only, see if anyone wants to work on speeds on roads
* TODO: Link `data-analyses` repo PR when it's merged, how we created these datasets
* #15 